### PR TITLE
Add Next.js boilerplate overview and sample website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,29 @@
-## Hi there 👋
+# Next.js Enterprise Boilerplate
 
-<!--
-**elias-hivemind/elias-hivemind** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+Jumpstart your enterprise project with our feature-packed, high-performance Next.js boilerplate. This repo contains a minimal example site that showcases the available tooling.
 
-Here are some ideas to get you started:
+## Features
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+- **Next.js** – Fast by default, with config optimized for performance.
+- **Tailwind CSS** – A utility-first CSS framework for rapid UI development.
+- **ESLint & Prettier** – For clean, consistent, and error-free code.
+- **Extremely strict TypeScript** with `ts-reset` for ultimate type safety.
+- **Bundle analyzer plugin** – Keep an eye on your bundle size.
+- **Jest & React Testing Library** – Rock-solid unit and integration tests.
+- **Playwright** – Write end-to-end tests like a pro.
+- **Storybook** – Create, test, and showcase your components.
+- **Smoke Testing & Acceptance Tests** – For confidence in your deployments.
+- **Conventional commits git hook** – Keep your commit history neat and tidy.
+- **Observability** – Open Telemetry integration for seamless monitoring.
+- **Absolute imports** – No more spaghetti imports.
+- **Health checks** – Kubernetes-compatible for robust deployments.
+- **Radix UI** – Headless UI components for endless customization.
+- **CVA** – Create a consistent, reusable, and atomic design system.
+- **Renovate BOT** – Auto-updating dependencies, so you can focus on coding.
+- **Patch-package** – Fix external dependencies without losing your mind.
+- **Components coupling & cohesion graph** – Manage component relationships.
+- **GitHub Actions** – Pre-configured actions for bundle size and performance stats.
+- **Automated ChatGPT Code Reviews** – Stay on the cutting edge with AI-powered code reviews!
+- **Semantic Release** – For automatic changelog generation.
+
+The demo website lives in the [`website`](website/) folder.

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,1 @@
+This folder contains a minimal static website for the **Next.js Enterprise Boilerplate**. It demonstrates the features listed in the project README. Due to environment restrictions, this is only a static HTML representation.

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Next.js Enterprise Boilerplate</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; line-height: 1.6; }
+    h1 { color: #111; }
+    ul { max-width: 600px; }
+  </style>
+</head>
+<body>
+  <h1>Next.js Enterprise Boilerplate</h1>
+  <p>Jumpstart your enterprise project with our feature-packed, high-performance Next.js boilerplate. Experience rapid UI development, AI-powered code reviews, and an extensive suite of tools for a smooth and enjoyable development process.</p>
+  <ul>
+    <li>Next.js - Fast by default, with config optimized for performance.</li>
+    <li>Tailwind CSS - A utility-first CSS framework for rapid UI development.</li>
+    <li>ESLint & Prettier - For clean, consistent, and error-free code.</li>
+    <li>Extremely strict TypeScript with <code>ts-reset</code> for ultimate type safety.</li>
+    <li>Bundle analyzer plugin - Keep an eye on your bundle size.</li>
+    <li>Jest & React Testing Library - Rock-solid unit and integration tests.</li>
+    <li>Playwright - Write end-to-end tests like a pro.</li>
+    <li>Storybook - Create, test, and showcase your components.</li>
+    <li>Smoke Testing & Acceptance Tests - For confidence in your deployments.</li>
+    <li>Conventional commits git hook - Keep your commit history neat and tidy.</li>
+    <li>Observability - Open Telemetry integration for seamless monitoring.</li>
+    <li>Absolute imports - No more spaghetti imports.</li>
+    <li>Health checks - Kubernetes-compatible for robust deployments.</li>
+    <li>Radix UI - Headless UI components for endless customization.</li>
+    <li>CVA - Create a consistent, reusable, and atomic design system.</li>
+    <li>Renovate BOT - Auto-updating dependencies, so you can focus on coding.</li>
+    <li>Patch-package - Fix external dependencies without losing your mind.</li>
+    <li>Components coupling & cohesion graph - Manage component relationships.</li>
+    <li>GitHub Actions - Pre-configured actions for bundle size and performance stats.</li>
+    <li>Automated ChatGPT Code Reviews - Stay on the cutting edge with AI-powered code reviews!</li>
+    <li>Semantic Release - For automatic changelog generation.</li>
+  </ul>
+  <p>For more information, visit <a href="https://mlinzi.io/">mlinzi.io</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document features in README
- add `website` with a minimal static HTML sample based on the boilerplate description

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688d457fd9148331958eac96826339a7